### PR TITLE
List patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,27 +83,39 @@ be removed regardless of it's own payload.
 -------------------------------------------------------
 
 <a name="lookup"></a>
-### instance.lookup(obj)
+### instance.lookup(obj [, opts])
 
 Looks up the first entry that matches the given obj. A match happens
 when all properties of the added pattern matches with the one in the
 passed obj. If a payload was provided it will be returned instead of
 the pattern.
 
+Options:
+ * `patterns: true`, if you want to retrieve only patterns, not
+   payloads
+
 -------------------------------------------------------
 <a name="iterator"></a>
-### instance.iterator(obj)
+### instance.iterator(obj [, opts])
 
 Returns an iterator, which is an object with a `next` method. `next`
 will return the next pattern that matches the object or `null` if there
 are no more.
 
+Options:
+ * `patterns: true`, if you want to retrieve only patterns, not
+   payloads
+
 -------------------------------------------------------
 <a name="list"></a>
-### instance.list(obj)
+### instance.list(obj [, opts])
 
 Returns all patterns that matches the object. If a payload was provided
 this will be returned instead of the pattern.
+
+Options:
+ * `patterns: true`, if you want to retrieve only patterns, not
+   payloads
 
 ## Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Options:
 Returns an iterator, which is an object with a `next` method. `next`
 will return the next pattern that matches the object or `null` if there
 are no more.
+If `obj` is null, all patterns/payload will be returned.
 
 Options:
  * `patterns: true`, if you want to retrieve only patterns, not
@@ -112,6 +113,7 @@ Options:
 
 Returns all patterns that matches the object. If a payload was provided
 this will be returned instead of the pattern.
+If `obj` is null, all patterns/payload will be returned.
 
 Options:
  * `patterns: true`, if you want to retrieve only patterns, not

--- a/bloomrun.js
+++ b/bloomrun.js
@@ -97,13 +97,13 @@ BloomRun.prototype.remove = function (pattern, payload) {
   return this
 }
 
-BloomRun.prototype.lookup = function (pattern) {
-  var iterator = new Iterator(this, pattern)
+BloomRun.prototype.lookup = function (pattern, opts) {
+  var iterator = new Iterator(this, pattern, opts)
   return iterator.next()
 }
 
-BloomRun.prototype.list = function (pattern) {
-  var iterator = new Iterator(this, pattern)
+BloomRun.prototype.list = function (pattern, opts) {
+  var iterator = new Iterator(this, pattern, opts)
   var list = []
   var current = null
 

--- a/lib/iterator.js
+++ b/lib/iterator.js
@@ -3,13 +3,15 @@
 var matchingBuckets = require('./matchingBuckets')
 var deepPartialMatch = require('./deepPartialMatch')
 
-function Iterator (parent, obj) {
+function Iterator (parent, obj, opts) {
   if (!(this instanceof Iterator)) {
-    return new Iterator(this, parent)
+    // this is parent
+    return new Iterator(this, parent, obj)
   }
 
   this.parent = parent
   this.pattern = obj
+  this.onlyPatterns = opts && opts.patterns
 
   this.buckets = matchingBuckets(parent._buckets, obj, parent._properties)
 
@@ -27,7 +29,11 @@ Iterator.prototype.next = function () {
   var current = this.buckets[this.i].data[this.k]
 
   if (deepPartialMatch(current.pattern, this.pattern)) {
-    match = current.payload
+    if (this.onlyPatterns) {
+      match = current.pattern
+    } else {
+      match = current.payload
+    }
   }
 
   if (++this.k === this.buckets[this.i].data.length) {

--- a/lib/iterator.js
+++ b/lib/iterator.js
@@ -13,7 +13,11 @@ function Iterator (parent, obj, opts) {
   this.pattern = obj
   this.onlyPatterns = opts && opts.patterns
 
-  this.buckets = matchingBuckets(parent._buckets, obj, parent._properties)
+  if (obj) {
+    this.buckets = matchingBuckets(parent._buckets, obj, parent._properties)
+  } else {
+    this.buckets = parent._buckets
+  }
 
   this.i = 0
   this.k = 0
@@ -28,7 +32,7 @@ Iterator.prototype.next = function () {
 
   var current = this.buckets[this.i].data[this.k]
 
-  if (deepPartialMatch(current.pattern, this.pattern)) {
+  if (!this.pattern || deepPartialMatch(current.pattern, this.pattern)) {
     if (this.onlyPatterns) {
       match = current.pattern
     } else {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   "devDependencies": {
     "fastbench": "^1.0.0",
     "faucet": "0.0.1",
-    "nanite-drain": "^0.1.0",
     "patrun": "^0.4.4",
     "pre-commit": "^1.1.1",
     "standard": "^5.0.0",

--- a/test.js
+++ b/test.js
@@ -184,3 +184,52 @@ test('removing causes filters to be rebuilt', function (t) {
   t.equal(instance.lookup({ group: '123' }), secondPattern)
   t.deepEqual(instance.lookup({ userId: 'DCF' }), secondPattern)
 })
+
+test('patterns can be listed while using payloads', function (t) {
+  t.plan(1)
+
+  var instance = bloomrun()
+  var pattern1 = { group: '123', userId: 'ABC' }
+  var pattern2 = { group: '123', userId: 'DEF' }
+  var payloadOne = drain(function (msg, done) { done() })
+  var payloadTwo = drain(function (msg, done) { done() })
+
+  instance.add(pattern1, payloadOne)
+  instance.add(pattern2, payloadTwo)
+
+  t.deepEqual(instance.list({ group: '123' }, { patterns: true }), [pattern1, pattern2])
+})
+
+test('patterns can be looked up while using payloads', function (t) {
+  t.plan(1)
+
+  var instance = bloomrun()
+  var pattern1 = { group: '123', userId: 'ABC' }
+  var pattern2 = { group: '123', userId: 'DEF' }
+  var payloadOne = drain(function (msg, done) { done() })
+  var payloadTwo = drain(function (msg, done) { done() })
+
+  instance.add(pattern1, payloadOne)
+  instance.add(pattern2, payloadTwo)
+
+  t.equal(instance.lookup({ group: '123' }, { patterns: true }), pattern1)
+})
+
+test('iterators can be used to fetch only patterns', function (t) {
+  t.plan(3)
+
+  var instance = bloomrun()
+  var pattern1 = { group: '123', userId: 'ABC' }
+  var pattern2 = { group: '123', userId: 'DEF' }
+  var payloadOne = drain(function (msg, done) { done() })
+  var payloadTwo = drain(function (msg, done) { done() })
+
+  instance.add(pattern1, payloadOne)
+  instance.add(pattern2, payloadTwo)
+
+  var iterator = instance.iterator({ group: '123' }, { patterns: true })
+
+  t.equal(iterator.next(), pattern1)
+  t.equal(iterator.next(), pattern2)
+  t.equal(iterator.next(), null)
+})

--- a/test.js
+++ b/test.js
@@ -2,7 +2,6 @@
 
 var test = require('tape')
 var bloomrun = require('./')
-var drain = require('nanite-drain')
 
 test('null is returned if pattern is not found', function (t) {
   t.plan(1)
@@ -151,8 +150,9 @@ test('complex payloads are matched correctly', function (t) {
 
   var instance = bloomrun()
   var pattern = { group: '123', userId: 'ABC' }
-  var payloadOne = drain(function (msg, done) { done() })
-  var payloadTwo = drain(function (msg, done) { done() })
+
+  function payloadOne () { }
+  function payloadTwo () { }
 
   instance.add(pattern, payloadOne)
   instance.add(pattern, payloadTwo)
@@ -191,8 +191,9 @@ test('patterns can be listed while using payloads', function (t) {
   var instance = bloomrun()
   var pattern1 = { group: '123', userId: 'ABC' }
   var pattern2 = { group: '123', userId: 'DEF' }
-  var payloadOne = drain(function (msg, done) { done() })
-  var payloadTwo = drain(function (msg, done) { done() })
+
+  function payloadOne () { }
+  function payloadTwo () { }
 
   instance.add(pattern1, payloadOne)
   instance.add(pattern2, payloadTwo)
@@ -206,8 +207,9 @@ test('patterns can be looked up while using payloads', function (t) {
   var instance = bloomrun()
   var pattern1 = { group: '123', userId: 'ABC' }
   var pattern2 = { group: '123', userId: 'DEF' }
-  var payloadOne = drain(function (msg, done) { done() })
-  var payloadTwo = drain(function (msg, done) { done() })
+
+  function payloadOne () { }
+  function payloadTwo () { }
 
   instance.add(pattern1, payloadOne)
   instance.add(pattern2, payloadTwo)
@@ -221,8 +223,9 @@ test('iterators can be used to fetch only patterns', function (t) {
   var instance = bloomrun()
   var pattern1 = { group: '123', userId: 'ABC' }
   var pattern2 = { group: '123', userId: 'DEF' }
-  var payloadOne = drain(function (msg, done) { done() })
-  var payloadTwo = drain(function (msg, done) { done() })
+
+  function payloadOne () { }
+  function payloadTwo () { }
 
   instance.add(pattern1, payloadOne)
   instance.add(pattern2, payloadTwo)
@@ -240,8 +243,9 @@ test('listing all payloads', function (t) {
   var instance = bloomrun()
   var pattern1 = { group: '123', userId: 'ABC' }
   var pattern2 = { group: '123', userId: 'DEF' }
-  var payloadOne = drain(function (msg, done) { done() })
-  var payloadTwo = drain(function (msg, done) { done() })
+
+  function payloadOne () { }
+  function payloadTwo () { }
 
   instance.add(pattern1, payloadOne)
   instance.add(pattern2, payloadTwo)
@@ -255,8 +259,9 @@ test('listing all patterns', function (t) {
   var instance = bloomrun()
   var pattern1 = { group: '123', userId: 'ABC' }
   var pattern2 = { group: '123', userId: 'DEF' }
-  var payloadOne = drain(function (msg, done) { done() })
-  var payloadTwo = drain(function (msg, done) { done() })
+
+  function payloadOne () { }
+  function payloadTwo () { }
 
   instance.add(pattern1, payloadOne)
   instance.add(pattern2, payloadTwo)

--- a/test.js
+++ b/test.js
@@ -233,3 +233,33 @@ test('iterators can be used to fetch only patterns', function (t) {
   t.equal(iterator.next(), pattern2)
   t.equal(iterator.next(), null)
 })
+
+test('listing all payloads', function (t) {
+  t.plan(1)
+
+  var instance = bloomrun()
+  var pattern1 = { group: '123', userId: 'ABC' }
+  var pattern2 = { group: '123', userId: 'DEF' }
+  var payloadOne = drain(function (msg, done) { done() })
+  var payloadTwo = drain(function (msg, done) { done() })
+
+  instance.add(pattern1, payloadOne)
+  instance.add(pattern2, payloadTwo)
+
+  t.deepEqual(instance.list(), [payloadOne, payloadTwo])
+})
+
+test('listing all patterns', function (t) {
+  t.plan(1)
+
+  var instance = bloomrun()
+  var pattern1 = { group: '123', userId: 'ABC' }
+  var pattern2 = { group: '123', userId: 'DEF' }
+  var payloadOne = drain(function (msg, done) { done() })
+  var payloadTwo = drain(function (msg, done) { done() })
+
+  instance.add(pattern1, payloadOne)
+  instance.add(pattern2, payloadTwo)
+
+  t.deepEqual(instance.list(null, { patterns: true }), [pattern1, pattern2])
+})


### PR DESCRIPTION
Adds the ability to list patterns properly:

1. support empty patterns in `list()` and `iterator()`, these will return all matching payloads
2. adds an `patterns: true` option to `lookup()`, `list()` and `iterator()`, to return the patterns, not the payload.

It also remove the devDependency to nanite-drain.

@mcdonnelldean can you please review this?