### PR TITLE
Added in regexp support, if another matching key is found

### DIFF
--- a/lib/deepMatch.js
+++ b/lib/deepMatch.js
@@ -5,6 +5,10 @@ function deepPartialMatch (a, b) {
 
   if (a === b) {
     return true
+  } else if (a instanceof RegExp) {
+    return a.test(b)
+  } else if (b instanceof RegExp) {
+    return b.test(a)
   } else if (typeof a !== 'object' || typeof b !== 'object') {
     return false
   }

--- a/test.js
+++ b/test.js
@@ -35,6 +35,30 @@ test('payload is returned instead of pattern if it exists', function (t) {
   t.deepEqual(instance.lookup(pattern), payload)
 })
 
+test('regexp support in the lookup', function (t) {
+  t.plan(1)
+
+  var instance = bloomrun()
+  var pattern = { cmd: 'save', prefs: 'userId' }
+  var payload = '1234'
+
+  instance.add(pattern, payload)
+
+  t.deepEqual(instance.lookup({ cmd: 'save', prefs: /user.*/ }), payload)
+})
+
+test('regexp support in the pattern', function (t) {
+  t.plan(1)
+
+  var instance = bloomrun()
+  var pattern = { cmd: 'save', prefs: /user.*/ }
+  var payload = '1234'
+
+  instance.add(pattern, payload)
+
+  t.deepEqual(instance.lookup({ cmd: 'save', prefs: 'userId' }), payload)
+})
+
 test('deep pattern matching', function (t) {
   t.plan(1)
 


### PR DESCRIPTION
This would need another key-value pair to be matching, otherwise we can't match the bucket.