### PR TITLE
Beyond insertion order, match elements with more elements first

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![npm][npm-badge]][npm-url]
 
 A js pattern matcher based on bloom filters, inspired by [patrun](http://npm.im/patrun).
-But different: 10x faster, and with results returned in __insertion order__.
+But different: 10x faster, and with results that can be returned in __insertion order__ or __depth order__.
 
 * [Install](#install)
 * [Example](#example)
@@ -56,9 +56,16 @@ goodbye()
 
 -------------------------------------------------------
 <a name="constructor"></a>
-### bloomrun()
+### bloomrun([opts])
 
 Creates a new instance of Bloomrun.
+
+Options are:
+
+* `indexing`: it can be either `insertion` (default) or `depth`;
+  if set to `insertion`, it will try to match entries in insertion order;
+  if set to `depth`, it will try to match entries with the most
+  properties first.
 
 -------------------------------------------------------
 <a name="add"></a>

--- a/bench.js
+++ b/bench.js
@@ -26,7 +26,8 @@ var threeEntries = (function () {
 
   function threeEntries (done) {
     var result = instance.lookup({
-      something: 'else'
+      something: 'else',
+      answer: 42
     })
     if (!result) {
       throw new Error('muahah')
@@ -60,7 +61,8 @@ var fiveHundredEntries = (function () {
 
   function fiveHundredEntries (done) {
     var result = instance.lookup({
-      bigCounter: '99'
+      bigCounter: '99',
+      small3: 99
     })
     if (!result) {
       throw new Error('muahah')
@@ -78,6 +80,7 @@ var fiveHundredEntriesAndProperties = (function () {
   function fiveHundredEntriesAndProperties (done) {
     var result = instance.lookup({
       bigCounter: '99',
+      small3: 99,
       something: 'else'
     })
     if (!result) {
@@ -96,7 +99,7 @@ var fiveHundredEntriesAndKnownProperties = (function () {
   function fiveHundredEntriesAndKnownProperties (done) {
     var result = instance.lookup({
       bigCounter: '99',
-      small4: '99'
+      small4: 99
     })
     if (!result) {
       throw new Error('muahah')
@@ -145,7 +148,8 @@ var patrunThreeEntries = (function () {
 
   function patrunThreeEntries (done) {
     var result = instance.list({
-      something: 'else'
+      something: 'else',
+      answer: 42
     })
     if (!result) {
       throw new Error('muahah')

--- a/bloomrun.js
+++ b/bloomrun.js
@@ -6,6 +6,7 @@ var PatternSet = require('./lib/patternSet')
 var genKeys = require('./lib/genKeys')
 var matchingBuckets = require('./lib/matchingBuckets')
 var deepMatch = require('./lib/deepMatch')
+var deepSort = require('./lib/deepSort')
 var Set = require('es6-set')
 
 function BloomRun (opts) {
@@ -13,6 +14,7 @@ function BloomRun (opts) {
     return new BloomRun(opts)
   }
 
+  this._isDeep = opts && opts.indexing === 'depth'
   this._buckets = []
   this._properties = new Set()
 }
@@ -71,8 +73,12 @@ BloomRun.prototype.add = function (pattern, payload) {
     properties.add(key)
   })
 
-  var patternSet = new PatternSet(pattern, payload)
+  var patternSet = new PatternSet(pattern, payload, this._isDeep)
   bucket.data.push(patternSet)
+
+  if (this._isDeep) {
+    bucket.data.sort(deepSort)
+  }
 
   return this
 }

--- a/lib/deepSort.js
+++ b/lib/deepSort.js
@@ -1,0 +1,13 @@
+'use strict'
+
+function deepSort (a, b) {
+  if (a.magic > b.magic) {
+    return -1
+  } else if (a.magic < b.magic) {
+    return 1
+  } else {
+    return 0
+  }
+}
+
+module.exports = deepSort

--- a/lib/patternSet.js
+++ b/lib/patternSet.js
@@ -1,8 +1,31 @@
 'use strict'
 
-function PatternSet (pattern, payload) {
+function PatternSet (pattern, payload, isDeep) {
   this.pattern = pattern
   this.payload = payload || pattern
+  this.magic = 0
+
+  if (isDeep) {
+    this.magic = calcMagic(pattern)
+  }
+}
+
+function calcMagic (pattern) {
+  var keys = Object.keys(pattern)
+  var length = keys.length
+  var result = 0
+  var key
+
+  for (var i = 0; i < length; i++) {
+    key = keys[i]
+    if (typeof pattern[key] === 'object') {
+      result += calcMagic(pattern[key])
+    } else {
+      result++
+    }
+  }
+
+  return result
 }
 
 module.exports = PatternSet

--- a/test.js
+++ b/test.js
@@ -119,7 +119,7 @@ test('do not match if not fully matching - #18', function (t) {
   }), 24)
 })
 
-test('multiple matches is supported', function (t) {
+test('multiple matches are supported', function (t) {
   t.plan(1)
 
   var instance = bloomrun()
@@ -337,4 +337,65 @@ test('matching numbers', function (t) {
 
   t.deepEqual(instance.lookup(pattern), pattern)
   t.deepEqual(instance.list(pattern), [pattern])
+})
+
+test('order support', function (t) {
+  t.plan(1)
+
+  var instance = bloomrun()
+  var pattern1 = { group: '123' }
+  var pattern2 = { group: '123', another: 'value' }
+
+  function payloadOne () { }
+  function payloadTwo () { }
+
+  instance.add(pattern1, payloadOne)
+  instance.add(pattern2, payloadTwo)
+
+  t.equal(instance.lookup({ group: '123', another: 'value' }), payloadOne)
+})
+
+test('depth support', function (t) {
+  t.plan(1)
+
+  var instance = bloomrun({ indexing: 'depth' })
+  var pattern1 = { group: '123' }
+  var pattern2 = { group: '123', another: 'value' }
+
+  function payloadOne () { }
+  function payloadTwo () { }
+
+  instance.add(pattern1, payloadOne)
+  instance.add(pattern2, payloadTwo)
+
+  t.equal(instance.lookup({ group: '123', another: 'value' }), payloadTwo)
+})
+
+test('recursive depth support', function (t) {
+  t.plan(1)
+
+  var instance = bloomrun({ indexing: 'depth' })
+  var pattern1 = { group: '123', some: { key: 'value' } }
+  var pattern2 = {
+    group: '123',
+    some: {
+      key: 'value',
+      a: 'b'
+    }
+  }
+
+  function payloadOne () { }
+  function payloadTwo () { }
+
+  instance.add(pattern1, payloadOne)
+  instance.add(pattern2, payloadTwo)
+
+  t.equal(instance.lookup({
+    group: '123',
+    some: {
+      key: 'value',
+      a: 'b',
+      c: 'd'
+    }
+  }), payloadTwo)
 })

--- a/test.js
+++ b/test.js
@@ -323,3 +323,18 @@ test('listing all patterns', function (t) {
 
   t.deepEqual(instance.list(null, { patterns: true }), [pattern1, pattern2])
 })
+
+test('matching numbers', function (t) {
+  t.plan(2)
+
+  var instance = bloomrun()
+  var pattern = {
+    something: 'else',
+    answer: 42
+  }
+
+  instance.add(pattern)
+
+  t.deepEqual(instance.lookup(pattern), pattern)
+  t.deepEqual(instance.list(pattern), [pattern])
+})


### PR DESCRIPTION
This should bring bloomrun almost on par with patrun: it allows to match patterns with more properties before the others.

@mcdonnelldean please review.

Fixes #23.