### PR TITLE
rm es6-set - shave 80% off browser build size, drop 0.10 and old browser support

### DIFF
--- a/bloomrun.js
+++ b/bloomrun.js
@@ -7,7 +7,6 @@ var genKeys = require('./lib/genKeys')
 var matchingBuckets = require('./lib/matchingBuckets')
 var deepMatch = require('./lib/deepMatch')
 var deepSort = require('./lib/deepSort')
-var Set = require('es6-set')
 
 function BloomRun (opts) {
   if (!(this instanceof BloomRun)) {

--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
   "repository": "https://github.com/mcollina/bloomrun.git",
   "license": "MIT",
   "dependencies": {
-    "bloomfilter": "0.0.16",
-    "es6-set": "^0.1.1"
+    "bloomfilter": "0.0.16"
   },
   "devDependencies": {
     "coveralls": "^2.11.6",


### PR DESCRIPTION
```sh
browserify -r bloomrun | wc -c 
49671
```

after removal

```sh
browserify -r bloomrun | wc -c 
10987
```

Support for Set is from Node 0.12 and up, browser support is from ie11, safari 8, android 5.1, safari ios 8, and FF and chrome have had it for ages too

Support for for very old browsers can be in the users hands (just include a global es6 shim)

