### PR TITLE
Correctly support Regex and default lookup

### DIFF
--- a/bloomrun.js
+++ b/bloomrun.js
@@ -59,7 +59,7 @@ function removeProperty (key) {
 }
 
 BloomRun.prototype.default = function (payload) {
-  this._defaultResult = payload || payload
+  this._defaultResult = payload
 }
 
 BloomRun.prototype.add = function (pattern, payload) {

--- a/bloomrun.js
+++ b/bloomrun.js
@@ -16,6 +16,7 @@ function BloomRun (opts) {
   this._isDeep = opts && opts.indexing === 'depth'
   this._buckets = []
   this._properties = new Set()
+  this._defaultResult = null
 }
 
 function addPatterns (toAdd) {
@@ -56,6 +57,10 @@ function removeProperty (key) {
 }
 
 BloomRun.prototype.add = function (pattern, payload) {
+  if (Object.keys(pattern).length === 0 && pattern.constructor === Object) {
+    this._defaultResult = payload || payload
+  }
+
   var buckets = matchingBuckets(this._buckets, pattern)
   var bucket
   var properties = this._properties
@@ -104,7 +109,7 @@ BloomRun.prototype.remove = function (pattern, payload) {
 
 BloomRun.prototype.lookup = function (pattern, opts) {
   var iterator = new Iterator(this, pattern, opts)
-  return iterator.next()
+  return iterator.next() || this._defaultResult
 }
 
 BloomRun.prototype.list = function (pattern, opts) {

--- a/lib/iterator.js
+++ b/lib/iterator.js
@@ -2,6 +2,7 @@
 
 var matchingBuckets = require('./matchingBuckets')
 var deepMatch = require('./deepMatch')
+var onlyRegex = require('./onlyRegex')
 
 function Iterator (parent, obj, opts) {
   if (!(this instanceof Iterator)) {
@@ -13,11 +14,17 @@ function Iterator (parent, obj, opts) {
   this.onlyPatterns = opts && opts.patterns
 
   if (obj) {
-    this.buckets = matchingBuckets(parent._buckets, obj, parent._properties)
+    if (onlyRegex(obj)) {
+      this.buckets = parent._buckets
+    } else {
+      this.buckets = matchingBuckets(parent._buckets, obj, parent._properties)
+    }
+  } else {
+    this.buckets = parent._buckets
   }
 
-  if (!this.buckets || this.buckets.length < 1) {
-    this.buckets = parent._buckets
+  if (this.parent._regexBucket.data.length > 0) {
+    this.buckets.push(this.parent._regexBucket)
   }
 
   this.i = 0

--- a/lib/iterator.js
+++ b/lib/iterator.js
@@ -5,7 +5,6 @@ var deepMatch = require('./deepMatch')
 
 function Iterator (parent, obj, opts) {
   if (!(this instanceof Iterator)) {
-    // this is parent
     return new Iterator(this, parent, obj)
   }
 
@@ -15,7 +14,9 @@ function Iterator (parent, obj, opts) {
 
   if (obj) {
     this.buckets = matchingBuckets(parent._buckets, obj, parent._properties)
-  } else {
+  }
+
+  if (!this.buckets || this.buckets.length < 1) {
     this.buckets = parent._buckets
   }
 

--- a/lib/onlyRegex.js
+++ b/lib/onlyRegex.js
@@ -1,0 +1,18 @@
+'use strict'
+
+function onlyRegex (pattern) {
+  var match = false
+
+  for (var i = 0; i < Object.keys(pattern).length; i++) {
+    if (pattern[Object.keys(pattern)[i]] instanceof RegExp) {
+      match = true
+    } else if (match) {
+      match = false
+      break
+    }
+  }
+
+  return match
+}
+
+module.exports = onlyRegex

--- a/lib/onlyRegex.js
+++ b/lib/onlyRegex.js
@@ -3,8 +3,8 @@
 function onlyRegex (pattern) {
   var match = false
 
-  for (var i = 0; i < Object.keys(pattern).length; i++) {
-    if (pattern[Object.keys(pattern)[i]] instanceof RegExp) {
+  for (var key in pattern) {
+    if (pattern[key] instanceof RegExp) {
       match = true
     } else if (match) {
       match = false

--- a/test.js
+++ b/test.js
@@ -29,10 +29,9 @@ test('default match is supported', function (t) {
   t.plan(1)
 
   var instance = bloomrun()
-  var pattern = {}
   var payload = { cmd: 'set-policy' }
 
-  instance.add(pattern, payload)
+  instance.default(payload)
 
   t.deepEqual(instance.lookup({foo: 'bar'}), payload)
 })
@@ -61,6 +60,18 @@ test('regexp support in the lookup', function (t) {
   t.deepEqual(instance.lookup({ prefs: /user.*/ }), payload)
 })
 
+test('regexp plus props support in the lookup', function (t) {
+  t.plan(1)
+
+  var instance = bloomrun()
+  var pattern = { cmd: 'save', prefs: 'userId' }
+  var payload = '1234'
+
+  instance.add(pattern, payload)
+
+  t.deepEqual(instance.lookup({ cmd: 'save', prefs: /user.*/ }), payload)
+})
+
 test('regexp support in the pattern', function (t) {
   t.plan(1)
 
@@ -71,6 +82,18 @@ test('regexp support in the pattern', function (t) {
   instance.add(pattern, payload)
 
   t.deepEqual(instance.lookup({ prefs: 'userId' }), payload)
+})
+
+test('regexp plus props support in the pattern', function (t) {
+  t.plan(1)
+
+  var instance = bloomrun()
+  var pattern = { cmd: 'save', prefs: /user.*/ }
+  var payload = '1234'
+
+  instance.add(pattern, payload)
+
+  t.deepEqual(instance.lookup({ cmd: 'save', prefs: 'userId' }), payload)
 })
 
 test('deep pattern matching', function (t) {

--- a/test.js
+++ b/test.js
@@ -25,6 +25,18 @@ test('pattern is returned on match', function (t) {
   t.deepEqual(instance.lookup(pattern), pattern)
 })
 
+test('default match is supported', function (t) {
+  t.plan(1)
+
+  var instance = bloomrun()
+  var pattern = {}
+  var payload = { cmd: 'set-policy' }
+
+  instance.add(pattern, payload)
+
+  t.deepEqual(instance.lookup({foo: 'bar'}), payload)
+})
+
 test('payload is returned instead of pattern if it exists', function (t) {
   t.plan(1)
 

--- a/test.js
+++ b/test.js
@@ -41,24 +41,24 @@ test('regexp support in the lookup', function (t) {
   t.plan(1)
 
   var instance = bloomrun()
-  var pattern = { cmd: 'save', prefs: 'userId' }
+  var pattern = { prefs: 'userId' }
   var payload = '1234'
 
   instance.add(pattern, payload)
 
-  t.deepEqual(instance.lookup({ cmd: 'save', prefs: /user.*/ }), payload)
+  t.deepEqual(instance.lookup({ prefs: /user.*/ }), payload)
 })
 
 test('regexp support in the pattern', function (t) {
   t.plan(1)
 
   var instance = bloomrun()
-  var pattern = { cmd: 'save', prefs: /user.*/ }
+  var pattern = { prefs: /user.*/ }
   var payload = '1234'
 
   instance.add(pattern, payload)
 
-  t.deepEqual(instance.lookup({ cmd: 'save', prefs: 'userId' }), payload)
+  t.deepEqual(instance.lookup({ prefs: 'userId' }), payload)
 })
 
 test('deep pattern matching', function (t) {


### PR DESCRIPTION
@mcollina @davidmarkclements Looks like Regex isn't actually supported. See failure.

**EDIT**

Default lookup and Regex are now supported but there is a perf hit at 500+ entries. This is because in order to check regexs we need to always check all buckets.

I think we need two changes to undo the perf penalty,

1. Mark a bucket when it contains a regex, regex buckets are always returned on matching
2. If an input to lookup contains a regex and returns no matches, test all buckets.

This means adding regex's will slow your instance down but this should be assumed since it is essentially subverting the point of bucketing in the first place.

Some points to note.

- If regexs are used in lookup only that lookup suffers a perf hit, all others do not
- If a regex is used when adding a pattern, all lookups suffer a perf hit.

The perf hit on adding regexs is because each lookup will always check N number of buckets where N is equal to it's matches plus any buckets with regex's. 