### PR TITLE
Closes #50, depth indexing preserves insertion order for same pattern

### DIFF
--- a/lib/bucket.js
+++ b/lib/bucket.js
@@ -3,6 +3,7 @@
 var sorted = require('sorted-array-functions')
 var match = require('./match')
 var onlyRegex = require('./onlyRegex')
+var reverseSort = require('./reverseSort')
 
 function Bucket (parent) {
   this.data = []
@@ -12,7 +13,8 @@ function Bucket (parent) {
 }
 
 Bucket.prototype.add = function (set) {
-  sorted.add(this.data, set, this._algo)
+  sorted.add(this.data, set, this.magic !== set.magic ? this._algo : reverseSort)
+
   if (this._isDeep) {
     if (this.magic < set.magic) {
       this.magic = set.magic

--- a/lib/reverseSort.js
+++ b/lib/reverseSort.js
@@ -1,0 +1,7 @@
+'use strict'
+
+function reverseSort (a, b) {
+  return 1
+}
+
+module.exports = reverseSort

--- a/test.js
+++ b/test.js
@@ -521,3 +521,21 @@ test('issue#46 - pattern is not equals', function (t) {
 
   t.deepEqual(instance.lookup(pattern2), null)
 })
+
+test('depth indexing preserves insertion order for same pattern', function (t) {
+  t.plan(1)
+
+  var instance = bloomrun({ indexing: 'depth' })
+  var pattern = { group: '123', another: 'value' }
+
+  function payloadOne () { }
+  function payloadTwo () { }
+
+  instance.add(pattern, payloadOne)
+  instance.add(pattern, payloadTwo)
+
+  t.deepEqual(instance.list({ group: '123', another: 'value' }), [
+    payloadOne,
+    payloadTwo
+  ])
+})


### PR DESCRIPTION
Resolves #50. Seems like a bit of a hack but it’s simple enough. Added a reverse sort file to stick with  codebase convention. Would love to have your input.
Thanks in advance,
