### PR TITLE
test: patterns with nested objects are supported

### DIFF
--- a/bloomrun.js
+++ b/bloomrun.js
@@ -35,20 +35,18 @@ Bloomrun.prototype.add = function (pattern, payload) {
 
   for (var key in pattern) {
     if (pattern.hasOwnProperty(key)) {
-      if (typeof pattern[key] !== 'object') {
-        if (!this._tree[key]) {
-          this._tree[key] = {}
-        }
-        bucket = this._tree[key][pattern[key]]
-
-        if (!bucket) {
-          bucket = new Bucket(this)
-          this._buckets.push(bucket)
-          this._tree[key][pattern[key]] = bucket
-        }
-
-        bucket.add(patternSet)
+      if (!this._tree[key]) {
+        this._tree[key] = {}
       }
+      bucket = this._tree[key][pattern[key]]
+
+      if (!bucket) {
+        bucket = new Bucket(this)
+        this._buckets.push(bucket)
+        this._tree[key][pattern[key]] = bucket
+      }
+
+      bucket.add(patternSet)
     }
   }
 
@@ -79,16 +77,14 @@ Bloomrun.prototype.remove = function (pattern, payload) {
 
   for (var key in pattern) {
     if (pattern.hasOwnProperty(key)) {
-      if (typeof pattern[key] !== 'object') {
-        if (this._tree[key] && this._tree[key][pattern[key]]) {
-          bucket = this._tree[key][pattern[key]]
+      if (this._tree[key] && this._tree[key][pattern[key]]) {
+        bucket = this._tree[key][pattern[key]]
 
-          if (bucket.remove(pattern, payload)) {
-            removeBucket(this._buckets, bucket)
-            bucket.forEach(addPatternSet, this)
-            if (bucket.data.length === 0) {
-              delete this._tree[key][pattern[key]]
-            }
+        if (bucket.remove(pattern, payload)) {
+          removeBucket(this._buckets, bucket)
+          bucket.forEach(addPatternSet, this)
+          if (bucket.data.length === 0) {
+            delete this._tree[key][pattern[key]]
           }
         }
       }

--- a/lib/match.js
+++ b/lib/match.js
@@ -8,6 +8,8 @@ function equal (a, b) {
     result = safeEqual(a, b)
   } else if (a instanceof RegExp) {
     result = a.test(b)
+  } else if (typeof a === 'object') {
+    result = match(a, b)
   }
 
   return result

--- a/test.js
+++ b/test.js
@@ -539,3 +539,17 @@ test('depth indexing preserves insertion order for same pattern', function (t) {
     payloadTwo
   ])
 })
+
+test('patterns with nested objects are supported', function (t) {
+  t.plan(3)
+
+  var instance = bloomrun()
+  var pattern = { group: '123', nested: { another: 'value' } }
+  instance.add(pattern, 'found me!')
+
+  t.deepEqual(instance.lookup(pattern), 'found me!')
+  t.deepEqual(instance.list(pattern), ['found me!'])
+
+  instance.remove(pattern, 'found me!')
+  t.deepEqual(instance.lookup(pattern), null)
+})


### PR DESCRIPTION
Covers the following case, which used to work in v2 but fails in v3.

```js
test('patterns with nested objects are supported', function (t) {
  t.plan(3)

  var instance = bloomrun()
  var pattern = { group: '123', something: { another: 'value' } }
  instance.add(pattern, 'found me!')

  t.deepEqual(instance.lookup(pattern), 'found me!')
  t.deepEqual(instance.list(pattern), ['found me!'])

  instance.remove(pattern, 'found me!')
  t.deepEqual(instance.lookup(pattern), null)
})
```