### PR TITLE
Add .npmignore to reduce NPM package size

### DIFF
--- a/assets/.npmignore
+++ b/assets/.npmignore
@@ -1,3 +1,4 @@
 *.jpg
 *.svg
 *.afdesign
+*.png


### PR DESCRIPTION
This will drastically reduce the size of the NPM package by removing unneeded files. It will keep the README.md. On my system the package size went from *68KB* to *25KB*.