### PR TITLE
Feature/#57 max call stack after removing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ node_modules
 .DS_Store
 
 profile-*
+package-lock.json

--- a/benchmarks/bench2.js
+++ b/benchmarks/bench2.js
@@ -2,7 +2,7 @@ const Benchmark = require('benchmark')
 const suite = new Benchmark.Suite()
 
 const patrun = require('patrun')({ gex: true })
-const bloomrun = require('.')()
+const bloomrun = require('..')()
 
 patrun.add({ role: 'test', action: 'other', id: '*' }, 'result')
 bloomrun.add({ role: 'test', action: 'other', id: /.*/ }, 'result')

--- a/bloomrun.js
+++ b/bloomrun.js
@@ -55,10 +55,6 @@ Bloomrun.prototype.add = function (pattern, payload) {
   return this
 }
 
-function addPatternSet (patternSet) {
-  this.add(patternSet.pattern, patternSet.payload)
-}
-
 function removeBucket (buckets, bucket) {
   for (var i = 0; i < buckets.length; i++) {
     if (bucket === buckets[i]) {
@@ -85,7 +81,6 @@ Bloomrun.prototype.remove = function (pattern, payload) {
 
           if (bucket.remove(pattern, payload)) {
             removeBucket(this._buckets, bucket)
-            bucket.forEach(addPatternSet, this)
             if (bucket.data.length === 0) {
               delete this._tree[key][pattern[key]]
             }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "JS object pattern matching",
   "main": "bloomrun.js",
   "scripts": {
-    "bench": "node bench.js",
+    "bench": "node benchmarks/bench2.js",
     "test": "standard | snazzy && tape test.js | faucet",
     "zuul-local": "zuul --open --local 8081 -- test.js",
     "coverage": "istanbul cover tape test.js > /dev/null; open coverage/lcov-report/index.html",
@@ -21,6 +21,7 @@
     "sorted-array-functions": "^1.0.0"
   },
   "devDependencies": {
+    "benchmark": "^2.1.4",
     "coveralls": "^2.13.1",
     "fastbench": "^1.0.0",
     "faucet": "0.0.1",

--- a/test.js
+++ b/test.js
@@ -544,7 +544,7 @@ test('issue#57 - Removing many pattern should not lead to finite recursion', fun
   t.plan(1)
 
   var instance = bloomrun()
-  const noop = () => 'test'
+  var noop = () => 'test'
 
   instance.add({ topic: 'math', cmd: 'add1' }, noop)
   instance.add({ topic: 'math', cmd: 'add2' }, noop)

--- a/test.js
+++ b/test.js
@@ -544,7 +544,7 @@ test('issue#57 - Removing many pattern should not lead to finite recursion', fun
   t.plan(1)
 
   var instance = bloomrun()
-  var noop = () => 'test'
+  var noop = function () { return 'test' }
 
   instance.add({ topic: 'math', cmd: 'add1' }, noop)
   instance.add({ topic: 'math', cmd: 'add2' }, noop)

--- a/test.js
+++ b/test.js
@@ -539,3 +539,36 @@ test('depth indexing preserves insertion order for same pattern', function (t) {
     payloadTwo
   ])
 })
+
+test('issue#57 - Removing many pattern should not lead to finite recursion', function (t) {
+  t.plan(1)
+
+  var instance = bloomrun()
+  const noop = () => 'test'
+
+  instance.add({ topic: 'math', cmd: 'add1' }, noop)
+  instance.add({ topic: 'math', cmd: 'add2' }, noop)
+  instance.add({ topic: 'math', cmd: 'add3' }, noop)
+  instance.add({ topic: 'math', cmd: 'add4' }, noop)
+  instance.add({ topic: 'math', cmd: 'add5' }, noop)
+  instance.add({ topic: 'math', cmd: 'add6' }, noop)
+  instance.add({ topic: 'math', cmd: 'add7' }, noop)
+  instance.add({ topic: 'math', cmd: 'add8' }, noop)
+  instance.add({ topic: 'math', cmd: 'add9' }, noop)
+  instance.add({ topic: 'math', cmd: 'add10' }, noop)
+  instance.add({ topic: 'math', cmd: 'add11' }, noop)
+  instance.add({ topic: 'math', cmd: 'add12' }, noop)
+  instance.add({ topic: 'math', cmd: 'add13' }, noop)
+  instance.add({ topic: 'math', cmd: 'add14' }, noop)
+  instance.add({ topic: 'math', cmd: 'add15' }, noop)
+  instance.add({ topic: 'math', cmd: 'add16' }, noop)
+  instance.add({ topic: 'math', cmd: 'add17' }, noop)
+
+  instance.list(null, {
+    patterns: true
+  }).forEach(function (element) {
+    instance.remove(element)
+  })
+
+  t.deepEqual(instance.list().length, 0)
+})


### PR DESCRIPTION
This fix looks strange to me because I don't know why you add the patternSet after we removed them but this will fix #57 and pass the tests. I found a different issue which is reproducible with and without these changes. If you run `npm run bench` the bloomrun benchmark will run into a memory leak are you aware of that?

```
> bloomrun@3.0.5 bench E:\Repositorys\bloomrun
> node benchmarks/bench2.js

patrun#add x 749,526 ops/sec ±0.83% (90 runs sampled)

<--- Last few GCs --->

[8628:000001E2755DF3C0]    17708 ms: Mark-sweep 1257.3 (1314.0) -> 1256.5 (1282.2) MB, 3720.9 / 0.0 ms  last resort
[8628:000001E2755DF3C0]    21439 ms: Mark-sweep 1256.5 (1282.2) -> 1256.4 (1282.2) MB, 3730.7 / 0.0 ms  last resort


<--- JS stacktrace --->

==== JS stack trace =========================================

Security context: 000003820D629891 <JS Object>
    2: add [E:\Repositorys\bloomrun\bloomrun.js:~27] [pc=000000CE3CFB55F3](this=000001EAF56DC8F1 <a Bloomrun with map 0000027ABE4DF271>,pattern=0000031FBB9C5E61 <an Object with map 0000027ABE4EC109>,payload=00000059FE7F8441 <String[12]: test pattern>)
    3: fn [E:\Repositorys\bloomrun\benchmarks\bench2.js:~13] [pc=000000CE3CFBBCD4](this=000001EAF56EC6A9 <a Benchmark with map 0000027ABE49AE59...

FATAL ERROR: CALL_AND_RETRY_LAST Allocation failed - JavaScript heap out of memory
```